### PR TITLE
allow api users to turn toggle CPU mode when making ml predictions

### DIFF
--- a/BoseGesture/Source/BoseGestureRecognizer.swift
+++ b/BoseGesture/Source/BoseGestureRecognizer.swift
@@ -14,6 +14,9 @@ import Foundation
  */
 public class BoseGestureRecognizer {
 
+    /// Enable/Disable GPU predictions
+    public var cpuMode = false
+
     /// Set of gestures that will be detected by the library. It defaults to all available gestures.
     public var enabledGestures = Set(BoseGestureType.all)
 

--- a/BoseGesture/Source/BoseMLGestureRecognizer.swift
+++ b/BoseGesture/Source/BoseMLGestureRecognizer.swift
@@ -49,6 +49,13 @@ internal class BoseMLGestureRecognizer: BoseGestureRecognizer {
         static let minConfidenceThreshold = 80
     }
 
+    /// Set MLPredictionOptions based on cpuMode
+    private var predictionOptions: MLPredictionOptions {
+        let options = MLPredictionOptions()
+        options.usesCPUOnly = cpuMode
+        return options
+    }
+
     /// Buffer for storing accel and gyro data
     private var accelDataBuffer = SensorData(bufferLength: Constants.samplesPerSensorDim, dataType: .vector3d)
     private var gyroDataBuffer = SensorData(bufferLength: Constants.samplesPerSensorDim, dataType: .vector3d)
@@ -136,7 +143,7 @@ internal class BoseMLGestureRecognizer: BoseGestureRecognizer {
             guard let dataBuffer = aggregatedDataBuffer else {
                 return
             }
-            if let gestureResult = try? gestureRecognitionModel.prediction(input: BoseMLGestureModelInput(IMU_Sensor_Bose_Frames: dataBuffer)) {
+            if let gestureResult = try? gestureRecognitionModel.prediction(input: BoseMLGestureModelInput(IMU_Sensor_Bose_Frames: dataBuffer), options: predictionOptions) {
                 (predictedGesture, predictedConfidence) = postProcessPrediction(gestureResult: gestureResult)
             }
             resetSensorsNewDataCount()


### PR DESCRIPTION
### Why is this change necessary?

While using the GestureLib-iOS sdk and attempting to retrieve model predictions while the client's app was not active, Apple throws a GPU permissions error.  Non-active applications are not allowed to perform GPU tasks.

### How does it address the issue?

We can offload this error by modifying the default  MLPredictionOptions and perform the predictions on the phones CPU https://developer.apple.com/documentation/coreml/mlmodel/2921292-prediction

### What potential side effects does this change have?

By having default `cpuMode` as false, any user has to explicitly toggle the flag.
Predictions may be slower off the GPU

### Steps to Test

Run `/Example` App's with new code
I also verified by running my current app with these proposed modifications