### PR TITLE
Lower Confidence to 50%

### DIFF
--- a/BoseGesture/Source/BoseMLGestureRecognizer.swift
+++ b/BoseGesture/Source/BoseMLGestureRecognizer.swift
@@ -46,7 +46,7 @@ internal class BoseMLGestureRecognizer: BoseGestureRecognizer {
         static let maxOccurencesForSuppressing = 6
 
         /// Threshold for reporting detected gesture to client
-        static let minConfidenceThreshold = 60
+        static let minConfidenceThreshold = 50
     }
 
     /// Set MLPredictionOptions based on cpuMode

--- a/BoseGesture/Source/BoseMLGestureRecognizer.swift
+++ b/BoseGesture/Source/BoseMLGestureRecognizer.swift
@@ -46,7 +46,7 @@ internal class BoseMLGestureRecognizer: BoseGestureRecognizer {
         static let maxOccurencesForSuppressing = 6
 
         /// Threshold for reporting detected gesture to client
-        static let minConfidenceThreshold = 80
+        static let minConfidenceThreshold = 60
     }
 
     /// Set MLPredictionOptions based on cpuMode


### PR DESCRIPTION
The current implementation of the SDK provides requires 80% for a gesture to trigger. This works very Frames but other devices consistently recognize gestures with around 60% confidence. To enable more accurate gesture recognition we can lower the minimum required confidence to 50% to ensure that all devices fire gestures correctly. In my testing there did not seem to be any false positives from lowering the confidence, but it did help remove false negatives.